### PR TITLE
Handle multiple Linux input devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # gomuxinput
+
+This project forwards keyboard and mouse events from a Linux host to a Windows client via TCP.
+It contains a simple server that reads evdev input events and sends them serialized over the network.
+The client receives events and injects them using Windows `SendInput`.
+
+The code is a minimal skeleton meant for further development and does not implement full event translation.
+
+## Usage
+
+The server can forward events from multiple evdev devices. Provide a comma-separated
+list of event device paths via the `-dev` flag:
+
+```
+go run ./cmd/server -dev /dev/input/event3,/dev/input/event4
+```
+
+The client connects to the server and injects the received events:
+
+```
+go run ./cmd/client
+```

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/gob"
+	"flag"
+	"log"
+	"net"
+
+	"gomuxinput/input"
+	"gomuxinput/protocol"
+)
+
+func main() {
+	var addr = flag.String("addr", "127.0.0.1:3333", "server address")
+	flag.Parse()
+
+	conn, err := net.Dial("tcp", *addr)
+	if err != nil {
+		log.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	log.Printf("connected to %s", *addr)
+
+	dec := gob.NewDecoder(conn)
+	sender := &input.WindowsSender{}
+
+	for {
+		var ev protocol.Event
+		if err := dec.Decode(&ev); err != nil {
+			log.Fatalf("decode: %v", err)
+		}
+		if err := sender.Send(&ev); err != nil {
+			log.Printf("send input: %v", err)
+		}
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"encoding/gob"
+	"flag"
+	"log"
+	"net"
+	"strings"
+	"sync"
+
+	"gomuxinput/input"
+	"gomuxinput/protocol"
+)
+
+func main() {
+	var (
+		addr     = flag.String("addr", "127.0.0.1:3333", "address to listen on")
+		devPaths = flag.String("dev", "/dev/input/event0", "comma-separated evdev devices")
+	)
+	flag.Parse()
+
+	paths := strings.Split(*devPaths, ",")
+
+	ln, err := net.Listen("tcp", *addr)
+	if err != nil {
+		log.Fatalf("listen: %v", err)
+	}
+	log.Printf("waiting for client on %s", *addr)
+
+	conn, err := ln.Accept()
+	if err != nil {
+		log.Fatalf("accept: %v", err)
+	}
+	defer conn.Close()
+	log.Printf("client connected: %s", conn.RemoteAddr())
+
+	enc := gob.NewEncoder(conn)
+
+	var readers []*input.LinuxReader
+	for _, p := range paths {
+		r, err := input.OpenLinuxReader(strings.TrimSpace(p))
+		if err != nil {
+			log.Fatalf("open input %s: %v", p, err)
+		}
+		readers = append(readers, r)
+		defer r.Close()
+	}
+
+	evCh := make(chan *protocol.Event)
+	var wg sync.WaitGroup
+	for _, r := range readers {
+		wg.Add(1)
+		go func(rd *input.LinuxReader) {
+			defer wg.Done()
+			for {
+				ev, err := rd.ReadEvent()
+				if err != nil {
+					log.Printf("read event: %v", err)
+					return
+				}
+				evCh <- ev
+			}
+		}(r)
+	}
+
+	go func() {
+		wg.Wait()
+		close(evCh)
+	}()
+
+	for ev := range evCh {
+		if err := enc.Encode(ev); err != nil {
+			log.Fatalf("encode: %v", err)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,4 @@
+module gomuxinput
+
+go 1.20
+

--- a/input/linux.go
+++ b/input/linux.go
@@ -1,0 +1,67 @@
+//go:build linux
+
+package input
+
+import (
+	"encoding/binary"
+	"os"
+
+	"gomuxinput/protocol"
+)
+
+// LinuxReader reads input events from an evdev device.
+type LinuxReader struct {
+	f *os.File
+}
+
+// OpenLinuxReader opens the given evdev device (e.g. /dev/input/event0).
+func OpenLinuxReader(devPath string) (*LinuxReader, error) {
+	f, err := os.Open(devPath)
+	if err != nil {
+		return nil, err
+	}
+	return &LinuxReader{f: f}, nil
+}
+
+// Close closes the underlying device.
+func (r *LinuxReader) Close() error {
+	if r.f != nil {
+		return r.f.Close()
+	}
+	return nil
+}
+
+// ReadEvent reads a single input event from the device.
+func (r *LinuxReader) ReadEvent() (*protocol.Event, error) {
+	// struct input_event { struct timeval time; unsigned short type, code; int value; };
+	var (
+		sec  int64
+		usec int64
+		typ  uint16
+		code uint16
+		val  int32
+	)
+	// timeval
+	if err := binary.Read(r.f, binary.LittleEndian, &sec); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(r.f, binary.LittleEndian, &usec); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(r.f, binary.LittleEndian, &typ); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(r.f, binary.LittleEndian, &code); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(r.f, binary.LittleEndian, &val); err != nil {
+		return nil, err
+	}
+	// No alignment adjustment is required in this simplified reader. In a
+	// full implementation you may need to account for struct padding.
+
+	ev := &protocol.Event{Type: typ, Code: code, Value: val}
+	_ = sec
+	_ = usec
+	return ev, nil
+}

--- a/input/windows.go
+++ b/input/windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package input
+
+import (
+	"syscall"
+	"unsafe"
+
+	"gomuxinput/protocol"
+)
+
+var (
+	user32        = syscall.NewLazyDLL("user32.dll")
+	procSendInput = user32.NewProc("SendInput")
+)
+
+// WindowsSender converts protocol events to Windows input events via SendInput.
+type WindowsSender struct{}
+
+// Send injects the given event using the Windows SendInput API. This is a
+// minimal placeholder implementation.
+func (s *WindowsSender) Send(ev *protocol.Event) error {
+	// Placeholder: map protocol.Event to INPUT structure.
+	// In a real implementation you would fill in the INPUT struct according
+	// to ev.Type, ev.Code and ev.Value. For simplicity we emit no real input.
+	var input [1]byte // dummy
+	_, _, err := procSendInput.Call(0, uintptr(unsafe.Pointer(&input[0])), 0)
+	if err != syscall.Errno(0) {
+		return err
+	}
+	return nil
+}

--- a/input/windows_stub.go
+++ b/input/windows_stub.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package input
+
+import "gomuxinput/protocol"
+
+// WindowsSender is a stub for non-Windows builds.
+type WindowsSender struct{}
+
+// Send does nothing on non-Windows platforms.
+func (s *WindowsSender) Send(ev *protocol.Event) error {
+	// Placeholder stub
+	_ = ev
+	return nil
+}

--- a/protocol/event.go
+++ b/protocol/event.go
@@ -1,0 +1,11 @@
+package protocol
+
+// Event represents a keyboard or mouse event transmitted over the wire.
+type Event struct {
+	// Type corresponds to evdev event type or Windows message.
+	Type uint16
+	// Code corresponds to key code or button code.
+	Code uint16
+	// Value carries the event value (press/release, relative movement, etc.).
+	Value int32
+}


### PR DESCRIPTION
## Summary
- expand README with usage instructions
- update server to accept multiple comma-separated device paths
- stream events from multiple evdev readers concurrently

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684de72191588321bf3d62e123b1dcbd