### PR TITLE
Implement Windows input mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # gomuxinput
+
+This project forwards keyboard and mouse events from a Linux host to a Windows client via TCP.
+It contains a simple server that reads evdev input events and sends them serialized over the network.
+The client receives events and injects them using Windows `SendInput`.
+
+The code is a minimal skeleton meant for further development and does not implement full event translation.
+
+## Usage
+
+The server can forward events from multiple evdev devices. Provide a comma-separated
+list of event device paths via the `-dev` flag:
+
+```
+go run ./cmd/server -dev /dev/input/event3,/dev/input/event4
+```
+
+The client connects to the server and injects the received events:
+
+```
+go run ./cmd/client
+```

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/gob"
+	"flag"
+	"log"
+	"net"
+
+	"gomuxinput/input"
+	"gomuxinput/protocol"
+)
+
+func main() {
+	var addr = flag.String("addr", "127.0.0.1:3333", "server address")
+	flag.Parse()
+
+	conn, err := net.Dial("tcp", *addr)
+	if err != nil {
+		log.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	log.Printf("connected to %s", *addr)
+
+	dec := gob.NewDecoder(conn)
+	sender := &input.WindowsSender{}
+
+	for {
+		var ev protocol.Event
+		if err := dec.Decode(&ev); err != nil {
+			log.Fatalf("decode: %v", err)
+		}
+		if err := sender.Send(&ev); err != nil {
+			log.Printf("send input: %v", err)
+		}
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"encoding/gob"
+	"flag"
+	"log"
+	"net"
+	"strings"
+	"sync"
+
+	"gomuxinput/input"
+	"gomuxinput/protocol"
+)
+
+func main() {
+	var (
+		addr     = flag.String("addr", "127.0.0.1:3333", "address to listen on")
+		devPaths = flag.String("dev", "/dev/input/event0", "comma-separated evdev devices")
+	)
+	flag.Parse()
+
+	paths := strings.Split(*devPaths, ",")
+
+	ln, err := net.Listen("tcp", *addr)
+	if err != nil {
+		log.Fatalf("listen: %v", err)
+	}
+	log.Printf("waiting for client on %s", *addr)
+
+	conn, err := ln.Accept()
+	if err != nil {
+		log.Fatalf("accept: %v", err)
+	}
+	defer conn.Close()
+	log.Printf("client connected: %s", conn.RemoteAddr())
+
+	enc := gob.NewEncoder(conn)
+
+	var readers []*input.LinuxReader
+	for _, p := range paths {
+		r, err := input.OpenLinuxReader(strings.TrimSpace(p))
+		if err != nil {
+			log.Fatalf("open input %s: %v", p, err)
+		}
+		readers = append(readers, r)
+		defer r.Close()
+	}
+
+	evCh := make(chan *protocol.Event)
+	var wg sync.WaitGroup
+	for _, r := range readers {
+		wg.Add(1)
+		go func(rd *input.LinuxReader) {
+			defer wg.Done()
+			for {
+				ev, err := rd.ReadEvent()
+				if err != nil {
+					log.Printf("read event: %v", err)
+					return
+				}
+				evCh <- ev
+			}
+		}(r)
+	}
+
+	go func() {
+		wg.Wait()
+		close(evCh)
+	}()
+
+	for ev := range evCh {
+		if err := enc.Encode(ev); err != nil {
+			log.Fatalf("encode: %v", err)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,4 @@
+module gomuxinput
+
+go 1.20
+

--- a/input/linux.go
+++ b/input/linux.go
@@ -1,0 +1,67 @@
+//go:build linux
+
+package input
+
+import (
+	"encoding/binary"
+	"os"
+
+	"gomuxinput/protocol"
+)
+
+// LinuxReader reads input events from an evdev device.
+type LinuxReader struct {
+	f *os.File
+}
+
+// OpenLinuxReader opens the given evdev device (e.g. /dev/input/event0).
+func OpenLinuxReader(devPath string) (*LinuxReader, error) {
+	f, err := os.Open(devPath)
+	if err != nil {
+		return nil, err
+	}
+	return &LinuxReader{f: f}, nil
+}
+
+// Close closes the underlying device.
+func (r *LinuxReader) Close() error {
+	if r.f != nil {
+		return r.f.Close()
+	}
+	return nil
+}
+
+// ReadEvent reads a single input event from the device.
+func (r *LinuxReader) ReadEvent() (*protocol.Event, error) {
+	// struct input_event { struct timeval time; unsigned short type, code; int value; };
+	var (
+		sec  int64
+		usec int64
+		typ  uint16
+		code uint16
+		val  int32
+	)
+	// timeval
+	if err := binary.Read(r.f, binary.LittleEndian, &sec); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(r.f, binary.LittleEndian, &usec); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(r.f, binary.LittleEndian, &typ); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(r.f, binary.LittleEndian, &code); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(r.f, binary.LittleEndian, &val); err != nil {
+		return nil, err
+	}
+	// No alignment adjustment is required in this simplified reader. In a
+	// full implementation you may need to account for struct padding.
+
+	ev := &protocol.Event{Type: typ, Code: code, Value: val}
+	_ = sec
+	_ = usec
+	return ev, nil
+}

--- a/input/windows.go
+++ b/input/windows.go
@@ -1,0 +1,112 @@
+//go:build windows
+
+package input
+
+import (
+	"syscall"
+	"unsafe"
+
+	"gomuxinput/protocol"
+)
+
+var (
+	user32        = syscall.NewLazyDLL("user32.dll")
+	procSendInput = user32.NewProc("SendInput")
+)
+
+// WindowsSender converts protocol events to Windows input events via SendInput.
+type WindowsSender struct{}
+
+// evdev event type constant for keys.
+const evKey = 0x01
+
+// Send injects the given event using the Windows SendInput API.
+
+// minimal map from evdev KEY_* codes to Windows VK_* codes.
+var keyMap = map[uint16]uint16{
+	30: 0x41, // KEY_A -> VK_A
+	48: 0x42, // KEY_B
+	46: 0x43, // KEY_C
+	32: 0x44, // KEY_D
+	18: 0x45, // KEY_E
+	33: 0x46, // KEY_F
+	34: 0x47, // KEY_G
+	35: 0x48, // KEY_H
+	23: 0x49, // KEY_I
+	36: 0x4A, // KEY_J
+	37: 0x4B, // KEY_K
+	38: 0x4C, // KEY_L
+	50: 0x4D, // KEY_M
+	49: 0x4E, // KEY_N
+	24: 0x4F, // KEY_O
+	25: 0x50, // KEY_P
+	16: 0x51, // KEY_Q
+	19: 0x52, // KEY_R
+	31: 0x53, // KEY_S
+	20: 0x54, // KEY_T
+	22: 0x55, // KEY_U
+	47: 0x56, // KEY_V
+	17: 0x57, // KEY_W
+	45: 0x58, // KEY_X
+	21: 0x59, // KEY_Y
+	44: 0x5A, // KEY_Z
+	2:  0x31, // KEY_1
+	3:  0x32, // KEY_2
+	4:  0x33, // KEY_3
+	5:  0x34, // KEY_4
+	6:  0x35, // KEY_5
+	7:  0x36, // KEY_6
+	8:  0x37, // KEY_7
+	9:  0x38, // KEY_8
+	10: 0x39, // KEY_9
+	11: 0x30, // KEY_0
+}
+
+func (s *WindowsSender) Send(ev *protocol.Event) error {
+	if ev.Type != evKey {
+		return nil // unsupported event type
+	}
+
+	vk, ok := keyMap[ev.Code]
+	if !ok {
+		// unmapped key
+		return nil
+	}
+
+	const (
+		inputKeyboard  = 1
+		keyeventfKeyup = 0x0002
+	)
+
+	type KEYBDINPUT struct {
+		wVk         uint16
+		wScan       uint16
+		dwFlags     uint32
+		time        uint32
+		dwExtraInfo uintptr
+	}
+
+	type INPUT struct {
+		Type uint32
+		Ki   KEYBDINPUT
+	}
+
+	var flags uint32
+	if ev.Value == 0 {
+		flags = keyeventfKeyup
+	}
+
+	in := INPUT{
+		Type: inputKeyboard,
+		Ki: KEYBDINPUT{
+			wVk:     vk,
+			dwFlags: flags,
+		},
+	}
+
+	_, _, err := procSendInput.Call(1, uintptr(unsafe.Pointer(&in)), unsafe.Sizeof(in))
+	if err != syscall.Errno(0) {
+		return err
+	}
+	return nil
+}

--- a/input/windows_stub.go
+++ b/input/windows_stub.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package input
+
+import "gomuxinput/protocol"
+
+// WindowsSender is a stub for non-Windows builds.
+type WindowsSender struct{}
+
+// Send does nothing on non-Windows platforms.
+func (s *WindowsSender) Send(ev *protocol.Event) error {
+	// Placeholder stub
+	_ = ev
+	return nil
+}

--- a/protocol/event.go
+++ b/protocol/event.go
@@ -1,0 +1,11 @@
+package protocol
+
+// Event represents a keyboard or mouse event transmitted over the wire.
+type Event struct {
+	// Type corresponds to evdev event type or Windows message.
+	Type uint16
+	// Code corresponds to key code or button code.
+	Code uint16
+	// Value carries the event value (press/release, relative movement, etc.).
+	Value int32
+}


### PR DESCRIPTION
## Summary
- implement WindowsSender.Send to translate evdev key events into SendInput calls

## Testing
- `go build ./...`
- `env GOOS=windows GOARCH=amd64 go build ./cmd/client`


------
https://chatgpt.com/codex/tasks/task_e_684de72191588321bf3d62e123b1dcbd